### PR TITLE
feat(ProvisionVolume): Update Volume Provisioning and Deletion using CVC

### DIFF
--- a/pkg/cvc/v1alpha1/build.go
+++ b/pkg/cvc/v1alpha1/build.go
@@ -38,9 +38,9 @@ func NewBuilder() *Builder {
 	}
 }
 
-// BuilderFrom returns new instance of Builder
+// BuildFrom returns new instance of Builder
 // from the provided api instance
-func BuilderFrom(cvc *apismaya.CStorVolumeClaim) *Builder {
+func BuildFrom(cvc *apismaya.CStorVolumeClaim) *Builder {
 	if cvc == nil {
 		b := NewBuilder()
 		b.errs = append(

--- a/pkg/cvc/v1alpha1/kubernetes.go
+++ b/pkg/cvc/v1alpha1/kubernetes.go
@@ -210,7 +210,7 @@ func defaultPatch(
 	updatedCVC, updateErr := cli.OpenebsV1alpha1().
 		CStorVolumeClaims(oldCVC.Namespace).
 		Patch(
-			oldCVC.Name, types.StrategicMergePatchType,
+			oldCVC.Name, types.MergePatchType,
 			patchBytes, subresources...,
 		)
 	if updateErr != nil {

--- a/pkg/cvc/v1alpha1/utils.go
+++ b/pkg/cvc/v1alpha1/utils.go
@@ -1,0 +1,30 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	apismaya "github.com/openebs/csi/pkg/apis/openebs.io/maya/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+// CVCKey returns an unique key of a CVC object,
+func CVCKey(cvc *apismaya.CStorVolumeClaim) string {
+	return fmt.Sprintf("%s/%s", cvc.Namespace, cvc.Name)
+}
+
+func getPatchData(oldObj, newObj interface{}) ([]byte, error) {
+	oldData, err := json.Marshal(oldObj)
+	if err != nil {
+		return nil, fmt.Errorf("marshal old object failed: %v", err)
+	}
+	newData, err := json.Marshal(newObj)
+	if err != nil {
+		return nil, fmt.Errorf("mashal new object failed: %v", err)
+	}
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, oldObj)
+	if err != nil {
+		return nil, fmt.Errorf("CreateTwoWayMergePatch failed: %v", err)
+	}
+	return patchBytes, nil
+}

--- a/pkg/iscsi/v1alpha1/iscsi_extra_utils.go
+++ b/pkg/iscsi/v1alpha1/iscsi_extra_utils.go
@@ -24,7 +24,8 @@ func getISCSIInfo(vol *apis.CSIVolume) (*iscsiDisk, error) {
 		lun:           vol.Spec.ISCSI.Lun,
 		Iface:         vol.Spec.ISCSI.IscsiInterface,
 		chapDiscovery: chapDiscovery,
-		chapSession:   chapSession}, nil
+		chapSession:   chapSession,
+	}, nil
 }
 
 func getISCSIInfoFromPV(req *csi.NodePublishVolumeRequest) (*iscsiDisk, error) {

--- a/pkg/iscsi/v1alpha1/iscsi_util.go
+++ b/pkg/iscsi/v1alpha1/iscsi_util.go
@@ -220,7 +220,10 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 			continue
 		}
 		// build discoverydb and discover iscsi target
-		b.exec.Run("iscsiadm", "-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", b.Iface, "-o", "new")
+		out, err = b.exec.Run("iscsiadm", "-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", b.Iface, "-o", "new")
+		if err != nil {
+			glog.Errorf("iscsi: failed to discover session with error: %s (%v)", string(out), err)
+		}
 		// update discoverydb with CHAP secret
 		err = updateISCSIDiscoverydb(b, tp)
 		if err != nil {

--- a/pkg/iscsi/v1alpha1/iscsi_util.go
+++ b/pkg/iscsi/v1alpha1/iscsi_util.go
@@ -48,17 +48,32 @@ func updateISCSIDiscoverydb(b iscsiDiskMounter, tp string) error {
 	if !b.chapDiscovery {
 		return nil
 	}
-	out, err := b.exec.Run("iscsiadm", "-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", b.Iface, "-o", "update", "-n", "discovery.sendtargets.auth.authmethod", "-v", "CHAP")
+	out, err := b.exec.Run(
+		"iscsiadm", "-m", "discoverydb",
+		"-t", "sendtargets", "-p", tp,
+		"-I", b.Iface, "-o", "update",
+		"-n", "discovery.sendtargets.auth.authmethod", "-v", "CHAP",
+	)
 	if err != nil {
-		return fmt.Errorf("iscsi: failed to update discoverydb with CHAP, output: %v", string(out))
+		return fmt.Errorf(
+			"iscsi: failed to update discoverydb with CHAP, output: %v",
+			string(out),
+		)
 	}
 
 	for _, k := range chapSt {
 		v := b.secret[k]
 		if len(v) > 0 {
-			out, err := b.exec.Run("iscsiadm", "-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", b.Iface, "-o", "update", "-n", k, "-v", v)
+			out, err := b.exec.Run(
+				"iscsiadm", "-m", "discoverydb",
+				"-t", "sendtargets", "-p", tp,
+				"-I", b.Iface, "-o", "update", "-n", k, "-v", v,
+			)
 			if err != nil {
-				return fmt.Errorf("iscsi: failed to update discoverydb key %q with value %q error: %v", k, v, string(out))
+				return fmt.Errorf(
+					"iscsi: failed to update discoverydb key %q with value %q error: %v",
+					k, v, string(out),
+				)
 			}
 		}
 	}
@@ -70,17 +85,33 @@ func updateISCSINode(b iscsiDiskMounter, tp string) error {
 		return nil
 	}
 
-	out, err := b.exec.Run("iscsiadm", "-m", "node", "-p", tp, "-T", b.Iqn, "-I", b.Iface, "-o", "update", "-n", "node.session.auth.authmethod", "-v", "CHAP")
+	out, err := b.exec.Run(
+		"iscsiadm", "-m", "node",
+		"-p", tp, "-T", b.Iqn, "-I", b.Iface,
+		"-o", "update", "-n", "node.session.auth.authmethod",
+		"-v", "CHAP",
+	)
 	if err != nil {
-		return fmt.Errorf("iscsi: failed to update node with CHAP, output: %v", string(out))
+		return fmt.Errorf(
+			"iscsi: failed to update node with CHAP, output: %v",
+			string(out),
+		)
 	}
 
 	for _, k := range chapSess {
 		v := b.secret[k]
 		if len(v) > 0 {
-			out, err := b.exec.Run("iscsiadm", "-m", "node", "-p", tp, "-T", b.Iqn, "-I", b.Iface, "-o", "update", "-n", k, "-v", v)
+			out, err := b.exec.Run(
+				"iscsiadm", "-m", "node",
+				"-p", tp, "-T", b.Iqn,
+				"-I", b.Iface, "-o", "update",
+				"-n", k, "-v", v,
+			)
 			if err != nil {
-				return fmt.Errorf("iscsi: failed to update node session key %q with value %q error: %v", k, v, string(out))
+				return fmt.Errorf(
+					"iscsi: failed to update node session key %q with value %q error: %v",
+					k, v, string(out),
+				)
 			}
 		}
 	}
@@ -94,12 +125,24 @@ type StatFunc func(string) (os.FileInfo, error)
 // GlobFunc returns an array of string
 type GlobFunc func(string) ([]string, error)
 
-func waitForPathToExist(devicePath *string, maxRetries int, deviceTransport string) bool {
+func waitForPathToExist(
+	devicePath *string,
+	maxRetries int,
+	deviceTransport string,
+) bool {
 	// This makes unit testing a lot easier
-	return waitForPathToExistInternal(devicePath, maxRetries, deviceTransport, os.Stat, filepath.Glob)
+	return waitForPathToExistInternal(
+		devicePath, maxRetries,
+		deviceTransport, os.Stat,
+		filepath.Glob,
+	)
 }
 
-func waitForPathToExistInternal(devicePath *string, maxRetries int, deviceTransport string, osStat StatFunc, filepathGlob GlobFunc) bool {
+func waitForPathToExistInternal(
+	devicePath *string, maxRetries int,
+	deviceTransport string, osStat StatFunc,
+	filepathGlob GlobFunc,
+) bool {
 	if devicePath == nil {
 		return false
 	}
@@ -113,9 +156,10 @@ func waitForPathToExistInternal(devicePath *string, maxRetries int, deviceTransp
 			if fpath == nil {
 				err = os.ErrNotExist
 			} else {
-				// There might be a case that fpath contains multiple device paths if
-				// multiple PCI devices connect to same iscsi target. We handle this
-				// case at subsequent logic. Pick up only first path here.
+				// There might be a case that fpath contains multiple
+				// device paths if multiple PCI devices connect to
+				// same iscsi target. We handle this case at subsequent logic.
+				// Pick up only first path here.
 				*devicePath = fpath[0]
 			}
 		}
@@ -151,7 +195,8 @@ func (util *ISCSIUtil) persistISCSI(conf iscsiDisk, mnt string) error {
 }
 
 func (util *ISCSIUtil) loadISCSI(conf *iscsiDisk, mnt string) error {
-	// NOTE: The iscsi config json is not deleted after logging out from target portals.
+	// NOTE: The iscsi config json is not deleted
+	// after logging out from target portals.
 	file := path.Join(mnt, conf.VolName+".json")
 	fp, err := os.Open(file)
 	if err != nil {
@@ -173,9 +218,15 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 	var iscsiTransport string
 	var lastErr error
 
-	out, err := b.exec.Run("iscsiadm", "-m", "iface", "-I", b.Iface, "-o", "show")
+	out, err := b.exec.Run(
+		"iscsiadm", "-m", "iface",
+		"-I", b.Iface, "-o", "show",
+	)
 	if err != nil {
-		glog.Errorf("iscsi: could not read iface %s error: %s", b.Iface, string(out))
+		glog.Errorf(
+			"iscsi: could not read iface %s error: %s",
+			b.Iface, string(out),
+		)
 		return "", err
 	}
 
@@ -183,13 +234,17 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 
 	bkpPortal := b.Portals
 
-	// create new iface and copy parameters from pre-configured iface to the created iface
+	// create new iface and copy parameters
+	// from pre-configured iface to the created iface
 	if b.InitiatorName != "" {
 		// new iface name is <target portal>:<volume name>
 		newIface := bkpPortal[0] + ":" + b.VolName
 		err = cloneIface(b, newIface)
 		if err != nil {
-			glog.Errorf("iscsi: failed to clone iface: %s error: %v", b.Iface, err)
+			glog.Errorf(
+				"iscsi: failed to clone iface: %s error: %v",
+				b.Iface, err,
+			)
 			return "", err
 		}
 		// update iface name
@@ -197,21 +252,41 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 	}
 
 	for _, tp := range bkpPortal {
-		// Rescan sessions to discover newly mapped LUNs. Do not specify the interface when rescanning
+		// Rescan sessions to discover newly mapped LUNs.
+		// Do not specify the interface when rescanning
 		// to avoid establishing additional sessions to the same target.
-		out, err := b.exec.Run("iscsiadm", "-m", "node", "-p", tp, "-T", b.Iqn, "-R")
+		out, err := b.exec.Run(
+			"iscsiadm", "-m", "node",
+			"-p", tp, "-T", b.Iqn, "-R",
+		)
 		if err != nil {
-			glog.Errorf("iscsi: failed to rescan session with error: %s (%v)", string(out), err)
+			glog.Errorf(
+				"iscsi: failed to rescan session with error: %s (%v)",
+				string(out), err,
+			)
 		}
 
 		if iscsiTransport == "" {
-			glog.Errorf("iscsi: could not find transport name in iface %s", b.Iface)
+			glog.Errorf(
+				"iscsi: could not find transport name in iface %s",
+				b.Iface,
+			)
 			return "", fmt.Errorf("Could not parse iface file for %s", b.Iface)
 		}
 		if iscsiTransport == "tcp" {
-			devicePath = strings.Join([]string{"/dev/disk/by-path/ip", tp, "iscsi", b.Iqn, "lun", b.lun}, "-")
+			devicePath = strings.Join(
+				[]string{
+					"/dev/disk/by-path/ip", tp, "iscsi", b.Iqn, "lun", b.lun,
+				}, "-",
+			)
 		} else {
-			devicePath = strings.Join([]string{"/dev/disk/by-path/pci", "*", "ip", tp, "iscsi", b.Iqn, "lun", b.lun}, "-")
+			devicePath = strings.Join(
+				[]string{
+					"/dev/disk/by-path/pci",
+					"*", "ip", tp, "iscsi", b.Iqn,
+					"lun", b.lun,
+				}, "-",
+			)
 		}
 
 		if exist := waitForPathToExist(&devicePath, 1, iscsiTransport); exist {
@@ -220,35 +295,70 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 			continue
 		}
 		// build discoverydb and discover iscsi target
-		out, err = b.exec.Run("iscsiadm", "-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", b.Iface, "-o", "new")
+		out, err = b.exec.Run(
+			"iscsiadm", "-m", "discoverydb",
+			"-t", "sendtargets", "-p", tp,
+			"-I", b.Iface, "-o", "new",
+		)
 		if err != nil {
-			glog.Errorf("iscsi: failed to discover session with error: %s (%v)", string(out), err)
+			glog.Errorf(
+				"iscsi: failed to discover session with error: %s (%v)",
+				string(out), err,
+			)
 		}
 		// update discoverydb with CHAP secret
 		err = updateISCSIDiscoverydb(b, tp)
 		if err != nil {
-			lastErr = fmt.Errorf("iscsi: failed to update discoverydb to portal %s error: %v", tp, err)
+			lastErr = fmt.Errorf(
+				"iscsi: failed to update discoverydb to portal %s error: %v",
+				tp, err,
+			)
 			continue
 		}
-		out, err = b.exec.Run("iscsiadm", "-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", b.Iface, "--discover")
+		out, err = b.exec.Run(
+			"iscsiadm", "-m", "discoverydb",
+			"-t", "sendtargets", "-p", tp,
+			"-I", b.Iface, "--discover",
+		)
 		if err != nil {
 			// delete discoverydb record
-			b.exec.Run("iscsiadm", "-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", b.Iface, "-o", "delete")
-			lastErr = fmt.Errorf("iscsi: failed to sendtargets to portal %s output: %s, err %v", tp, string(out), err)
+			b.exec.Run(
+				"iscsiadm", "-m", "discoverydb",
+				"-t", "sendtargets", "-p", tp,
+				"-I", b.Iface, "-o", "delete",
+			)
+			lastErr = fmt.Errorf(
+				"iscsi: failed to sendtargets to portal %s output: %s, err %v",
+				tp, string(out), err,
+			)
 			continue
 		}
 		err = updateISCSINode(b, tp)
 		if err != nil {
-			// failure to update node db is rare. But deleting record will likely impact those who already start using it.
-			lastErr = fmt.Errorf("iscsi: failed to update iscsi node to portal %s error: %v", tp, err)
+			// failure to update node db is rare.
+			// But deleting record will likely
+			// impact those who already start using it.
+			lastErr = fmt.Errorf(
+				"iscsi: failed to update iscsi node to portal %s error: %v",
+				tp, err,
+			)
 			continue
 		}
 		// login to iscsi target
-		out, err = b.exec.Run("iscsiadm", "-m", "node", "-p", tp, "-T", b.Iqn, "-I", b.Iface, "--login")
+		out, err = b.exec.Run(
+			"iscsiadm", "-m", "node", "-p", tp,
+			"-T", b.Iqn, "-I", b.Iface, "--login",
+		)
 		if err != nil {
 			// delete the node record from database
-			b.exec.Run("iscsiadm", "-m", "node", "-p", tp, "-I", b.Iface, "-T", b.Iqn, "-o", "delete")
-			lastErr = fmt.Errorf("iscsi: failed to attach disk: Error: %s (%v)", string(out), err)
+			b.exec.Run(
+				"iscsiadm", "-m", "node", "-p", tp,
+				"-I", b.Iface, "-T", b.Iqn, "-o", "delete",
+			)
+			lastErr = fmt.Errorf(
+				"iscsi: failed to attach disk: Error: %s (%v)",
+				string(out), err,
+			)
 			continue
 		}
 		if exist := waitForPathToExist(&devicePath, 10, iscsiTransport); !exist {
@@ -263,9 +373,19 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 
 	if len(devicePaths) == 0 {
 		// delete cloned iface
-		b.exec.Run("iscsiadm", "-m", "iface", "-I", b.Iface, "-o", "delete")
-		glog.Errorf("iscsi: failed to get any path for iscsi disk, last err seen:\n%v", lastErr)
-		return "", fmt.Errorf("failed to get any path for iscsi disk, last err seen:\n%v", lastErr)
+		b.exec.Run(
+			"iscsiadm", "-m", "iface",
+			"-I", b.Iface, "-o", "delete",
+		)
+		glog.Errorf(
+			"iscsi: failed to get any path for iscsi disk, last err seen:\n%v",
+			lastErr,
+		)
+		return "",
+			fmt.Errorf(
+				"failed to get any path for iscsi disk, last err seen:\n%v",
+				lastErr,
+			)
 	}
 	if lastErr != nil {
 		glog.Errorf("iscsi: last error occurred during iscsi init:\n%v", lastErr)
@@ -278,7 +398,9 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 	mntPath := b.targetPath
 	notMnt, err := b.mounter.IsLikelyNotMountPoint(mntPath)
 	if err != nil && !os.IsNotExist(err) {
-		return "", fmt.Errorf("Heuristic determination of mount point failed:%v", err)
+		return "",
+			fmt.Errorf(
+				"Heuristic determination of mount point failed:%v", err)
 	}
 	if !notMnt {
 		glog.Infof("iscsi: %s already mounted", mntPath)
@@ -303,7 +425,8 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 			continue
 		}
 		// check if the dev is using mpio and if so mount it via the dm-XX device
-		if mappedDevicePath := b.deviceUtil.FindMultipathDeviceForDevice(path); mappedDevicePath != "" {
+		mappedDevicePath := b.deviceUtil.FindMultipathDeviceForDevice(path)
+		if mappedDevicePath != "" {
 			devicePath = mappedDevicePath
 			break
 		}
@@ -320,29 +443,44 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 
 	err = b.mounter.FormatAndMount(devicePath, mntPath, b.fsType, options)
 	if err != nil {
-		glog.Errorf("iscsi: failed to mount iscsi volume %s [%s] to %s, error %v", devicePath, b.fsType, mntPath, err)
+		glog.Errorf(
+			"iscsi: failed to mount iscsi volume %s [%s] to %s, error %v",
+			devicePath, b.fsType, mntPath, err,
+		)
 	}
 
 	return devicePath, err
 }
 
 // DetachDisk logs out of the iSCSI volume and the corresponding path is removed
-func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, targetPath string) error {
+func (util *ISCSIUtil) DetachDisk(
+	c iscsiDiskUnmounter,
+	targetPath string,
+) error {
 	_, cnt, err := mount.GetDeviceNameFromMount(c.mounter, targetPath)
 	if err != nil {
-		glog.Errorf("iscsi detach disk: failed to get device from mnt: %s\nError: %v", targetPath, err)
+		glog.Errorf(
+			"iscsi detach disk: failed to get device from mnt: %s\nError: %v",
+			targetPath, err,
+		)
 		return err
 	}
 
 	if pathExists, pathErr := mount.PathExists(targetPath); pathErr != nil {
 		return fmt.Errorf("Error checking if path exists: %v", pathErr)
 	} else if !pathExists {
-		glog.Warningf("Warning: Unmount skipped because path does not exist: %v", targetPath)
+		glog.Warningf(
+			"Warning: Unmount skipped because path does not exist: %v",
+			targetPath,
+		)
 		return nil
 	}
 
 	if err = c.mounter.Unmount(targetPath); err != nil {
-		glog.Errorf("iscsi detach disk: failed to unmount: %s\nError: %v", targetPath, err)
+		glog.Errorf(
+			"iscsi detach disk: failed to unmount: %s\nError: %v",
+			targetPath, err,
+		)
 		return err
 	}
 	cnt--
@@ -356,25 +494,38 @@ func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, targetPath string) error
 
 	// load iscsi disk config from json file
 	if err := util.loadISCSI(c.iscsiDisk, targetPath); err == nil {
-		bkpPortal, iqn, iface, volName = c.iscsiDisk.Portals, c.iscsiDisk.Iqn, c.iscsiDisk.Iface, c.iscsiDisk.VolName
+		bkpPortal, iqn, iface, volName = c.iscsiDisk.Portals, c.iscsiDisk.Iqn,
+			c.iscsiDisk.Iface, c.iscsiDisk.VolName
 		initiatorName = c.iscsiDisk.InitiatorName
 	} else {
-		glog.Errorf("iscsi detach disk: failed to get iscsi config from path %s Error: %v", targetPath, err)
+		glog.Errorf(
+			"iscsi detach disk: failed to get iscsi config from path %s Error: %v",
+			targetPath, err,
+		)
 		return err
 	}
 	portals := removeDuplicate(bkpPortal)
 	if len(portals) == 0 {
-		return fmt.Errorf("iscsi detach disk: failed to detach iscsi disk. Couldn't get connected portals from configurations")
+		return fmt.Errorf(
+			"iscsi detach disk: failed to detach iscsi disk. Couldn't get connected portals from configurations",
+		)
 	}
 
 	for _, portal := range portals {
-		logoutArgs := []string{"-m", "node", "-p", portal, "-T", iqn, "--logout"}
-		deleteArgs := []string{"-m", "node", "-p", portal, "-T", iqn, "-o", "delete"}
+		logoutArgs := []string{
+			"-m", "node", "-p", portal, "-T", iqn, "--logout",
+		}
+		deleteArgs := []string{
+			"-m", "node", "-p", portal, "-T", iqn, "-o", "delete",
+		}
 		if found {
 			logoutArgs = append(logoutArgs, []string{"-I", iface}...)
 			deleteArgs = append(deleteArgs, []string{"-I", iface}...)
 		}
-		glog.Infof("iscsi: log out target %s iqn %s iface %s", portal, iqn, iface)
+		glog.Infof(
+			"iscsi: log out target %s iqn %s iface %s",
+			portal, iqn, iface,
+		)
 		out, err := c.exec.Run("iscsiadm", logoutArgs...)
 		if err != nil {
 			glog.Errorf("iscsi: failed to detach disk Error: %s", string(out))
@@ -383,7 +534,10 @@ func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, targetPath string) error
 		glog.Infof("iscsi: delete node record target %s iqn %s", portal, iqn)
 		out, err = c.exec.Run("iscsiadm", deleteArgs...)
 		if err != nil {
-			glog.Errorf("iscsi: failed to delete node record Error: %s", string(out))
+			glog.Errorf(
+				"iscsi: failed to delete node record Error: %s",
+				string(out),
+			)
 		}
 	}
 	// Delete the iface after all sessions have logged out
@@ -411,7 +565,8 @@ func extractTransportname(ifaceOutput string) (iscsiTransport string) {
 	}
 	iscsiTransport = rexOutput[1]
 
-	// While iface.transport_name is a required parameter, handle it being unspecified anyways
+	// While iface.transport_name is a required parameter,
+	// handle it being unspecified anyways
 	if iscsiTransport == "<empty>" {
 		iscsiTransport = "tcp"
 	}
@@ -434,7 +589,8 @@ func parseIscsiadmShow(output string) (map[string]string, error) {
 	params := make(map[string]string)
 	slice := strings.Split(output, "\n")
 	for _, line := range slice {
-		if !strings.HasPrefix(line, "iface.") || strings.Contains(line, "<empty>") {
+		if !strings.HasPrefix(line, "iface.") ||
+			strings.Contains(line, "<empty>") {
 			continue
 		}
 		iface := strings.Fields(line)
@@ -453,15 +609,24 @@ func parseIscsiadmShow(output string) (map[string]string, error) {
 func cloneIface(b iscsiDiskMounter, newIface string) error {
 	var lastErr error
 	// get pre-configured iface records
-	out, err := b.exec.Run("iscsiadm", "-m", "iface", "-I", b.Iface, "-o", "show")
+	out, err := b.exec.Run(
+		"iscsiadm", "-m", "iface",
+		"-I", b.Iface, "-o", "show",
+	)
 	if err != nil {
-		lastErr = fmt.Errorf("iscsi: failed to show iface records: %s (%v)", string(out), err)
+		lastErr = fmt.Errorf(
+			"iscsi: failed to show iface records: %s (%v)",
+			string(out), err,
+		)
 		return lastErr
 	}
 	// parse obtained records
 	params, err := parseIscsiadmShow(string(out))
 	if err != nil {
-		lastErr = fmt.Errorf("iscsi: failed to parse iface records: %s (%v)", string(out), err)
+		lastErr = fmt.Errorf(
+			"iscsi: failed to parse iface records: %s (%v)",
+			string(out), err,
+		)
 		return lastErr
 	}
 	// update initiatorname
@@ -469,15 +634,27 @@ func cloneIface(b iscsiDiskMounter, newIface string) error {
 	// create new iface
 	out, err = b.exec.Run("iscsiadm", "-m", "iface", "-I", newIface, "-o", "new")
 	if err != nil {
-		lastErr = fmt.Errorf("iscsi: failed to create new iface: %s (%v)", string(out), err)
+		lastErr = fmt.Errorf(
+			"iscsi: failed to create new iface: %s (%v)",
+			string(out), err,
+		)
 		return lastErr
 	}
 	// update new iface records
 	for key, val := range params {
-		_, err = b.exec.Run("iscsiadm", "-m", "iface", "-I", newIface, "-o", "update", "-n", key, "-v", val)
+		_, err = b.exec.Run(
+			"iscsiadm", "-m", "iface", "-I", newIface,
+			"-o", "update", "-n", key, "-v", val,
+		)
 		if err != nil {
-			b.exec.Run("iscsiadm", "-m", "iface", "-I", newIface, "-o", "delete")
-			lastErr = fmt.Errorf("iscsi: failed to update iface records: %s (%v). iface(%s) will be used", string(out), err, b.Iface)
+			b.exec.Run(
+				"iscsiadm", "-m", "iface",
+				"-I", newIface, "-o", "delete",
+			)
+			lastErr = fmt.Errorf(
+				"iscsi: failed to update iface records: %s (%v). iface(%s) will be used",
+				string(out), err, b.Iface,
+			)
 			break
 		}
 	}

--- a/pkg/payload/v1alpha1/delete.go
+++ b/pkg/payload/v1alpha1/delete.go
@@ -1,0 +1,41 @@
+/*
+Copyright © 2018-2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+// DeleteVolumeResponseBuilder helps building an
+// instance of csi DeleteVolumeResponse
+type DeleteVolumeResponseBuilder struct {
+	response *csi.DeleteVolumeResponse
+}
+
+// NewDeleteVolumeResponseBuilder returns a new
+// instance of DeleteVolumeResponseBuilder
+func NewDeleteVolumeResponseBuilder() *DeleteVolumeResponseBuilder {
+	return &DeleteVolumeResponseBuilder{
+		response: &csi.DeleteVolumeResponse{},
+	}
+}
+
+// Build returns the constructed instance
+// of csi DeleteVolumeResponse
+func (b *DeleteVolumeResponseBuilder) Build() *csi.DeleteVolumeResponse {
+	return b.response
+}

--- a/pkg/service/v1alpha1/controller.go
+++ b/pkg/service/v1alpha1/controller.go
@@ -75,12 +75,6 @@ func (cs *controller) CreateVolume(
 	cvc, err := utils.GetVolume(volName)
 	if err == nil && cvc != nil && cvc.DeletionTimestamp == nil {
 		goto createVolumeResponse
-	} else if cvc.DeletionTimestamp != nil {
-		return nil,
-			status.Error(
-				codes.Internal,
-				"Volume with same name is being deleted",
-			)
 	}
 
 	err = utils.ProvisionVolume(size, volName, configClass)

--- a/pkg/service/v1alpha1/node.go
+++ b/pkg/service/v1alpha1/node.go
@@ -58,12 +58,12 @@ func (ns *node) NodePublishVolume(
 		devicePath string
 	)
 
-	mountPath := req.GetTargetPath()
-	volumeID := req.GetVolumeId()
-
 	if err = ns.validateNodePublishReq(req); err != nil {
 		return nil, err
 	}
+
+	mountPath := req.GetTargetPath()
+	volumeID := req.GetVolumeId()
 
 	vol, err := csivol.NewBuilder().
 		WithName(req.GetVolumeId()).
@@ -207,6 +207,7 @@ func (ns *node) NodeUnpublishVolume(
 ) (*csi.NodeUnpublishVolumeResponse, error) {
 
 	var err error
+
 	if err = ns.validateNodeUnpublishReq(req); err != nil {
 		return nil, err
 	}
@@ -266,8 +267,7 @@ func (ns *node) NodeGetInfo(
 ) (*csi.NodeGetInfoResponse, error) {
 
 	return &csi.NodeGetInfoResponse{
-		NodeId:            ns.driver.config.NodeID,
-		MaxVolumesPerNode: 1,
+		NodeId: ns.driver.config.NodeID,
 	}, nil
 }
 

--- a/pkg/service/v1alpha1/service.go
+++ b/pkg/service/v1alpha1/service.go
@@ -85,14 +85,14 @@ func New(config *config.Config) *CSIDriver {
 		driver.cs = NewController(driver)
 
 	case "node":
-		utils.FetchAndUpdateVolInfos(config.NodeID)
+		// utils.FetchAndUpdateVolInfos(config.NodeID)
 
 		// Start monitor goroutine to monitor the
 		// mounted paths. If a path goes down or
 		// becomes read only (in case of RW mount
 		// points), this thread will fetch the path
 		// and relogin or remount
-		go utils.MonitorMounts()
+		// go utils.MonitorMounts()
 
 		driver.ns = NewNode(driver)
 	}

--- a/pkg/utils/v1alpha1/maya.go
+++ b/pkg/utils/v1alpha1/maya.go
@@ -100,7 +100,7 @@ func PatchCVCNodeID(volumeID, nodeID string) error {
 
 	newCVCObj, err := cvc.BuildFrom(oldCVCObj.DeepCopy()).
 		WithNodeID(nodeID).Build()
-	subresources := "spec"
+	subresources := "publish"
 	_, err = cvc.NewKubeclient().
 		WithNamespace(OpenEBSNamespace).
 		Patch(oldCVCObj, newCVCObj, subresources)

--- a/pkg/utils/v1alpha1/maya.go
+++ b/pkg/utils/v1alpha1/maya.go
@@ -100,10 +100,10 @@ func PatchCVCNodeID(volumeID, nodeID string) error {
 
 	newCVCObj, err := cvc.BuildFrom(oldCVCObj.DeepCopy()).
 		WithNodeID(nodeID).Build()
-	subresources := "publish"
 	_, err = cvc.NewKubeclient().
 		WithNamespace(OpenEBSNamespace).
-		Patch(oldCVCObj, newCVCObj, subresources)
+		Patch(oldCVCObj, newCVCObj)
+
 	return err
 }
 

--- a/pkg/utils/v1alpha1/maya.go
+++ b/pkg/utils/v1alpha1/maya.go
@@ -91,16 +91,19 @@ func IsCVCBound(volumeID string) (bool, error) {
 
 //PatchCVCNodeID patches the NodeID of CVC
 func PatchCVCNodeID(volumeID, nodeID string) error {
-	cvcObj, err := cvc.NewKubeclient().
+	oldCVCObj, err := cvc.NewKubeclient().
 		WithNamespace(OpenEBSNamespace).
 		Get(volumeID, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-	cvcObj, err = cvc.BuildFrom(cvcObj).
+
+	newCVCObj, err := cvc.BuildFrom(oldCVCObj.DeepCopy()).
 		WithNodeID(nodeID).Build()
-	//TODO Patch needs to be done over here instead of update
-	_, err = cvc.NewKubeclient().WithNamespace(OpenEBSNamespace).Update(cvcObj)
+	subresources := "spec"
+	_, err = cvc.NewKubeclient().
+		WithNamespace(OpenEBSNamespace).
+		Patch(oldCVCObj, newCVCObj, subresources)
 	return err
 }
 

--- a/pkg/utils/v1alpha1/maya.go
+++ b/pkg/utils/v1alpha1/maya.go
@@ -1,17 +1,14 @@
 package utils
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
-	"github.com/container-storage-interface/spec/lib/go/csi"
+	apis "github.com/openebs/csi/pkg/apis/openebs.io/core/v1alpha1"
 	apismaya "github.com/openebs/csi/pkg/apis/openebs.io/maya/v1alpha1"
-	errors "github.com/openebs/csi/pkg/generated/maya/errors/v1alpha1"
+	cstvol "github.com/openebs/csi/pkg/cstor/volume/v1alpha1"
+	cvc "github.com/openebs/csi/pkg/cvc/v1alpha1"
+	csivol "github.com/openebs/csi/pkg/volume/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -21,191 +18,108 @@ const (
 	gib100 int64 = gib * 100
 	tib    int64 = gib * 1024
 	tib100 int64 = tib * 100
+	// OpenebsConfigClass is the config class name passed to CSI from the
+	// storage class parameters
+	OpenebsConfigClass = "openebs.io/config-class"
+	// OpenebsVolumeID is the PV name passed to CSI
+	OpenebsVolumeID = "openebs.io/volumeID"
+	// CVCFinalizer is used for CVC protection so that cvc is not deleted until
+	// the underlying cv is deleted
+	CVCFinalizer = "cvc.openebs.io/finalizer"
+	// TargetLunID indicates the LUN ID at the target
+	TargetLunID = "0"
+	// DefaultIscsiInterface can be used when there is no specific
+	// IscsiInterface set
+	DefaultIscsiInterface = "default"
 )
 
-// TODO
-//  Need to remove the dependency of maya api server
-// Provisioning workflow should be tightly integrated
-// with Kubernetes based custom resources. This tight
-// integration helps in decoupling two or more
-// applications.
-//
-// ProvisionVolume sends a request to maya
-// apiserver to create a new CAS volume
-func ProvisionVolume(req *csi.CreateVolumeRequest) (*apismaya.CASVolume, error) {
-	casVolume := apismaya.CASVolume{}
-	casVolume.Spec.Capacity = strconv.FormatInt(req.GetCapacityRange().GetRequiredBytes(), 10)
+// ProvisionVolume creates a CstorVolumeClaim(cvc) CR,
+// watcher for cvc is present in maya-apiserver
+func ProvisionVolume(size int64, volName, configclass string) error {
 
-	parameters := req.GetParameters()
-	storageclass := parameters["storageclass"]
-	namespace := parameters["namespace"]
-
-	// creating a map b/c have to initialize the map
-	// using the make function before adding any elements
-	// to avoid nil map assignment error
-	mapLabels := make(map[string]string)
-
-	if storageclass == "" {
-		logrus.Errorf("volume is not specified with storageclass")
-	} else {
-		mapLabels[string(apismaya.StorageClassKey)] = storageclass
-		casVolume.Labels = mapLabels
+	annotations := map[string]string{
+		OpenebsConfigClass: configclass,
+		OpenebsVolumeID:    volName,
 	}
 
-	casVolume.Labels[string(apismaya.NamespaceKey)] = namespace
-	casVolume.Namespace = namespace
-	casVolume.Labels[string(apismaya.PersistentVolumeClaimKey)] =
-		parameters["persistentvolumeclaim"]
-	casVolume.Name = req.GetName()
-
-	logrus.Infof("verify if volume {%s} is already present", casVolume.Name)
-	err := ReadVolume(req.GetName(), namespace, storageclass, &casVolume)
-	if err == nil {
-		logrus.Infof("volume {%v} already present", req.GetName())
-		return &casVolume, nil
+	finalizers := []string{
+		CVCFinalizer,
 	}
 
-	if err.Error() != http.StatusText(404) {
-		// any error other than 404 is unexpected error
-		logrus.Errorf("failed to read volume {%s}: %v", req.GetName(), err)
-		return nil, err
+	sizeGi := strconv.FormatInt(size/gib, 10) + "Gi"
+
+	cvcObj, err := cvc.NewBuilder().
+		WithName(volName).
+		WithNamespace(OpenEBSNamespace).
+		WithAnnotations(annotations).
+		WithFinalizers(finalizers).
+		WithCapacity(sizeGi).
+		WithStatusPhase(apismaya.CStorVolumeClaimPhasePending).Build()
+	if err != nil {
+		return err
 	}
 
-	if err.Error() == http.StatusText(404) {
-		logrus.Infof("volume {%s} does not exist: will attempt to create", req.GetName())
-
-		err = CreateVolume(casVolume)
-		if err != nil {
-			logrus.Errorf(
-				"failed to create volume {%s}: %v",
-				req.GetName(),
-				err)
-			return nil, err
-		}
-
-		err = ReadVolume(req.GetName(), namespace, storageclass, &casVolume)
-		if err != nil {
-			logrus.Errorf("failed to read volume {%s}: %v", req.GetName(), err)
-			return nil, err
-		}
-
-		logrus.Infof("volume {%s} created successfully", req.GetName())
-	}
-
-	return &casVolume, nil
+	_, err = cvc.NewKubeclient().WithNamespace(OpenEBSNamespace).Create(cvcObj)
+	return err
 }
 
-// CreateVolume creates the CAS volume through
-// an API call to maya apiserver
-func CreateVolume(vol apismaya.CASVolume) error {
-
-	url := MAPIServerEndpoint + "/latest/volumes/"
-
-	// Marshal serializes the value provided into a json document
-	jsonValue, _ := json.Marshal(vol)
-
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
-	if err != nil {
-		logrus.Infof("error while creating newRequest: %v", err)
-		return err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-
-	c := &http.Client{
-		Timeout: timeout,
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		logrus.Errorf("Error when connecting maya-apiserver %v", err)
-		return err
-	}
-	defer resp.Body.Close()
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		logrus.Errorf("Unable to read response from maya-apiserver %v", err)
-		return err
-	}
-
-	code := resp.StatusCode
-	if code != http.StatusOK {
-		logrus.Errorf("%s: failed to create volume '%s': response: %+v",
-			http.StatusText(code), vol.Name, string(data))
-		return fmt.Errorf("%s: failed to create volume '%s': response: %+v",
-			http.StatusText(code), vol.Name, string(data))
-	}
-
-	logrus.Infof("volume {%s} created successfully", vol.Name)
-	return nil
+// GetVolume the corresponding CstorVolumeClaim(cvc) CR
+func GetVolume(volumeID string) (*apismaya.CStorVolumeClaim, error) {
+	return cvc.NewKubeclient().
+		WithNamespace(OpenEBSNamespace).
+		Get(volumeID, metav1.GetOptions{})
 }
 
-// ReadVolume to get the info of CAS volume through a API call to m-apiserver
-func ReadVolume(vname, namespace, storageclass string, obj interface{}) error {
-
-	url := MAPIServerEndpoint + "/latest/volumes/" + vname
-
-	logrus.Infof("[DEBUG] Get details for Volume :%v", string(vname))
-
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("namespace", namespace)
-	// passing storageclass info as a request header which will extracted by the
-	// Maya-apiserver to get the CAS template name
-	req.Header.Set(string(apismaya.StorageClassHeaderKey), storageclass)
-
-	c := &http.Client{
-		Timeout: timeout,
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		logrus.Errorf("Error when connecting to maya-apiserver %v", err)
-		return err
-	}
-	defer resp.Body.Close()
-
-	code := resp.StatusCode
-	if code != http.StatusOK {
-		logrus.Errorf("HTTP Status error from maya-apiserver: %v\n",
-			http.StatusText(code))
-		return errors.New(http.StatusText(code))
-	}
-	logrus.Info("volume Details Successfully Retrieved")
-	return json.NewDecoder(resp.Body).Decode(obj)
+// DeleteVolume deletes the corresponding CstorVolumeClaim(cvc) CR
+func DeleteVolume(volumeID string) (err error) {
+	err = cvc.NewKubeclient().WithNamespace(OpenEBSNamespace).Delete(volumeID)
+	return
 }
 
-// DeleteVolume deletes CAS volume through an
-// API call to maya apiserver
-func DeleteVolume(name, namespace string) error {
+// IsCVCBound returns if the CV is bound to CVC or not
+func IsCVCBound(volumeID string) (bool, error) {
+	cvcObj, err := cvc.NewKubeclient().
+		WithNamespace(OpenEBSNamespace).
+		Get(volumeID, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	if cvcObj.Status.Phase == apismaya.CStorVolumeClaimPhasePending {
+		return false, nil
+	}
+	return true, nil
+}
 
-	url := MAPIServerEndpoint + "/latest/volumes/" + name
-	req, err := http.NewRequest("DELETE", url, nil)
+//PatchCVCNodeID patches the NodeID of CVC
+func PatchCVCNodeID(volumeID, nodeID string) error {
+	cvcObj, err := cvc.NewKubeclient().
+		WithNamespace(OpenEBSNamespace).
+		Get(volumeID, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
+	cvcObj, err = cvc.BuilderFrom(cvcObj).
+		WithNodeID(nodeID).Build()
+	//TODO Patch needs to be done over here instead of update
+	_, err = cvc.NewKubeclient().WithNamespace(OpenEBSNamespace).Update(cvcObj)
+	return err
+}
 
-	req.Header.Set("namespace", namespace)
-	c := &http.Client{
-		Timeout: timeout,
-	}
-
-	resp, err := c.Do(req)
+//FetchAndUpdateISCSIDetails fetches the iSCSI details from cstor volume
+//resource and updates the corresponding csivolume resource
+func FetchAndUpdateISCSIDetails(volumeID string, vol *apis.CSIVolume) error {
+	getOptions := metav1.GetOptions{}
+	cv, err := cstvol.NewKubeclient().
+		WithNamespace(OpenEBSNamespace).
+		Get(volumeID, getOptions)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-
-	code := resp.StatusCode
-	if code != http.StatusOK {
-		return errors.Errorf(
-			"failed to delete volume {%s}: got http code {%s}",
-			url,
-			http.StatusText(code),
-		)
-	}
-
-	return nil
+	_, err = csivol.BuilderFrom(vol).
+		WithIQN(cv.Spec.Iqn).
+		WithTargetPortal(cv.Spec.TargetPortal).
+		WithLun(TargetLunID).
+		WithIscsiInterface(DefaultIscsiInterface).
+		Build()
+	return err
 }

--- a/pkg/utils/v1alpha1/utils.go
+++ b/pkg/utils/v1alpha1/utils.go
@@ -17,7 +17,6 @@ import (
 	service "github.com/openebs/csi/pkg/generated/maya/kubernetes/service/v1alpha1"
 	iscsi "github.com/openebs/csi/pkg/iscsi/v1alpha1"
 	"google.golang.org/grpc"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
@@ -195,32 +194,6 @@ func GetVolumeByName(volName string) (*apis.CSIVolume, error) {
 	}
 	return nil,
 		fmt.Errorf("volume name %s does not exit in the volumes list", volName)
-}
-
-// GetVolumeDetails returns a new instance of csiVolume filled with the
-// VolumeAttributes fetched from the corresponding PV and some additional info
-// required for remounting
-func GetVolumeDetails(volumeID, mountPath string, readOnly bool, mountOptions []string) (*apis.CSIVolume, error) {
-	pv, err := FetchPVDetails(volumeID)
-	if err != nil {
-		return nil, err
-	}
-	vol := apis.CSIVolume{}
-	cap := pv.Spec.Capacity[corev1.ResourceName(corev1.ResourceStorage)]
-	for _, accessmode := range pv.Spec.AccessModes {
-		vol.Spec.Volume.AccessModes = append(vol.Spec.Volume.AccessModes, string(accessmode))
-	}
-	vol.Spec.Volume.Name = volumeID
-	vol.Spec.Volume.FSType = pv.Spec.CSI.FSType
-	vol.Spec.Volume.Capacity = cap.String()
-	vol.Spec.Volume.MountPath = mountPath
-	vol.Spec.Volume.ReadOnly = readOnly
-	vol.Spec.Volume.MountOptions = mountOptions
-	vol.Spec.ISCSI.Iqn = pv.Spec.CSI.VolumeAttributes["iqn"]
-	vol.Spec.ISCSI.Lun = pv.Spec.CSI.VolumeAttributes["lun"]
-	vol.Spec.ISCSI.IscsiInterface = pv.Spec.CSI.VolumeAttributes["iscsiInterface"]
-	vol.Spec.ISCSI.TargetPortal = pv.Spec.CSI.VolumeAttributes["targetPortal"]
-	return &vol, nil
 }
 
 func listContains(mountPath string, list []mount.MountPoint) (*mount.MountPoint, bool) {

--- a/pkg/volume/v1alpha1/build.go
+++ b/pkg/volume/v1alpha1/build.go
@@ -36,9 +36,9 @@ func NewBuilder() *Builder {
 	}
 }
 
-// BuilderFrom returns new instance of Builder
+// BuildFrom returns new instance of Builder
 // from the provided api instance
-func BuilderFrom(volume *apis.CSIVolume) *Builder {
+func BuildFrom(volume *apis.CSIVolume) *Builder {
 	if volume == nil {
 		b := NewBuilder()
 		b.errs = append(

--- a/pkg/volume/v1alpha1/build.go
+++ b/pkg/volume/v1alpha1/build.go
@@ -147,13 +147,8 @@ func (b *Builder) WithMountPath(mountPath string) *Builder {
 
 // WithMountOptions sets the mountoptions of csi volume
 func (b *Builder) WithMountOptions(mountOptions []string) *Builder {
+	//Error is not being retured over here since this is an optional field
 	if len(mountOptions) == 0 {
-		b.errs = append(
-			b.errs,
-			errors.New(
-				"failed to build csi volume object: missing mountOptions",
-			),
-		)
 		return b
 	}
 	if b.volume.Object.Spec.Volume.MountOptions == nil {
@@ -166,13 +161,8 @@ func (b *Builder) WithMountOptions(mountOptions []string) *Builder {
 
 // WithMountOptionsNew sets the mountoptions of csi volume
 func (b *Builder) WithMountOptionsNew(mountOptions []string) *Builder {
+	//Error is not being retured over here since this is an optional field
 	if len(mountOptions) == 0 {
-		b.errs = append(
-			b.errs,
-			errors.New(
-				"failed to build csi volume object: missing mountOptions",
-			),
-		)
 		return b
 	}
 	b.volume.Object.Spec.Volume.MountOptions = nil


### PR DESCRIPTION
This PR updates the functionality for volume Creation/Deletion. Following are the APIs which have been updated:
1) CreateVolume(): Create CStorVolumeClaim(CVC) CR on receiving Create Volume Request at Controller. This will be created with empty nodeID and status marked as pending. Once this API responds success kubernetes sends a NodePublishVolume() request.
CVC Controller at maya waits for NodeID to be updated in the CVC to create the required volume components.
2) NodePublishVolume(): Patch nodeID to the previously created CVC CR and wait for status to be updated to bound by maya. The bound status implies that the required volume components have been created. Once the status is changed to bound, steps to mount the volume are processed
3) NodeUnPublishVolume(): Unmount the volume and remove NodeID from CVC.
4) DeleteVolume(): Delete CVC CR.
