### PR TITLE
chore(cvc): refactor cstorvolumeclaim schema

### DIFF
--- a/pkg/apis/openebs.io/maya/v1alpha1/cstor_volume_claim.go
+++ b/pkg/apis/openebs.io/maya/v1alpha1/cstor_volume_claim.go
@@ -47,7 +47,9 @@ type CStorVolumeClaimSpec struct {
 	// Capacity represents the actual resources of the underlying
 	// cstor volume.
 	Capacity corev1.ResourceList `json:"capacity"`
-
+	// ReplicaCount represents the actual replica count for the underlying
+	// cstor volume
+	ReplicaCount int `json:"replicaCount"`
 	// CStorVolumeRef contains the reference to CStorVolume i.e. CstorVolume Name
 	// This field will be updated by maya after cstor Volume has been
 	// provisioned

--- a/pkg/cvc/v1alpha1/build.go
+++ b/pkg/cvc/v1alpha1/build.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strconv"
+
 	apismaya "github.com/openebs/csi/pkg/apis/openebs.io/maya/v1alpha1"
 	errors "github.com/openebs/csi/pkg/generated/maya/errors/v1alpha1"
 	metav1 "k8s.io/api/core/v1"
@@ -307,6 +309,25 @@ func (b *Builder) WithCapacityQty(resCapacity resource.Quantity) *Builder {
 		metav1.ResourceName(metav1.ResourceStorage): resCapacity,
 	}
 	b.cvc.object.Spec.Capacity = resourceList
+	return b
+}
+
+// WithReplicaCount sets replica count of CStorVolumeClaim
+func (b *Builder) WithReplicaCount(count string) *Builder {
+
+	replicaCount, err := strconv.Atoi(count)
+	if err != nil {
+		b.errs = append(
+			b.errs,
+			errors.Wrapf(
+				err,
+				"failed to build cstorvolumeclaim object {%s}",
+				count,
+			),
+		)
+		return b
+	}
+	b.cvc.object.Spec.ReplicaCount = replicaCount
 	return b
 }
 

--- a/pkg/service/v1alpha1/controller.go
+++ b/pkg/service/v1alpha1/controller.go
@@ -24,7 +24,7 @@ import (
 	apismaya "github.com/openebs/csi/pkg/apis/openebs.io/maya/v1alpha1"
 	errors "github.com/openebs/csi/pkg/generated/maya/errors/v1alpha1"
 	csipayload "github.com/openebs/csi/pkg/payload/v1alpha1"
-	"github.com/openebs/csi/pkg/utils/v1alpha1"
+	utils "github.com/openebs/csi/pkg/utils/v1alpha1"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -70,6 +70,8 @@ func (cs *controller) CreateVolume(
 	volName := req.GetName()
 	size := req.GetCapacityRange().RequiredBytes
 	configClass := req.GetParameters()["configClass"]
+	rCount := req.GetParameters()["replicaCount"]
+	spcName := req.GetParameters()["storagePoolClaim"]
 
 	// verify if the volume has already been created
 	cvc, err := utils.GetVolume(volName)
@@ -77,7 +79,7 @@ func (cs *controller) CreateVolume(
 		goto createVolumeResponse
 	}
 
-	err = utils.ProvisionVolume(size, volName, configClass)
+	err = utils.ProvisionVolume(size, volName, rCount, configClass, spcName)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}


### PR DESCRIPTION
 - Update CVC schema struct with `ReplicaCount` type.
 - Add StoragePoolClaim (CstorPoolClusterClaim) name in CVC label
   while building cstor volume claim.

**CStorVolumeClaim object:**
```yaml
apiVersion: openebs.io/v1alpha1
kind: CStorVolumeClaim
metadata:
  annotations:
    openebs.io/config-class: openebs-cstor-sparse-auto
    openebs.io/volumeID: pvc-d030e3e4-a700-11e9-b527-42010a800279
  creationTimestamp: "2019-07-15T13:02:34Z"
  finalizers:
  - cvc.openebs.io/finalizer
  generation: 3
  labels:
    openebs.io/storage-pool-claim: cstor-sparse-pool
  name: pvc-d030e3e4-a700-11e9-b527-42010a800279
  namespace: openebs
  resourceVersion: "5114188"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-d030e3e4-a700-11e9-b527-42010a800279
  uid: d03bfcae-a700-11e9-b527-42010a800279
publish:
  nodeId: gke-prateek-helm-pool-1-38b7cbfe-rn9q
spec:
  capacity:
    storage: "5368709120"
  cstorVolumeRef:
    apiVersion: openebs.io/v1alpha1
    kind: CStorVolume
    name: pvc-d030e3e4-a700-11e9-b527-42010a800279
    namespace: openebs
    resourceVersion: "5114169"
    uid: e6cabbe3-a700-11e9-b527-42010a800279
  replicaCount: 3
status:
  phase: Bound
```
Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>