### PR TITLE
Add Status field to CSIVolume API and read CSIVolumeCRs while coming up

### DIFF
--- a/pkg/apis/openebs.io/core/v1alpha1/csivolume.go
+++ b/pkg/apis/openebs.io/core/v1alpha1/csivolume.go
@@ -30,7 +30,7 @@ type CSIVolume struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   CSIVolumeSpec   `json:"spec"`
-	Status CSIVolumeStatus `json: "status"`
+	Status CSIVolumeStatus `json:"status"`
 }
 
 // CSIVolumeSpec is the spec for a CStorVolume resource
@@ -41,7 +41,7 @@ type CSIVolumeSpec struct {
 	// ISCSIInfo specific to ISCSI protocol,
 	// this is filled only if the volume type
 	// is iSCSI
-	ISCSI ISCSIInfo `json: "iscsi"`
+	ISCSI ISCSIInfo `json:"iscsi"`
 }
 
 // VolumeInfo contains the volume related info

--- a/pkg/apis/openebs.io/core/v1alpha1/csivolume.go
+++ b/pkg/apis/openebs.io/core/v1alpha1/csivolume.go
@@ -29,7 +29,8 @@ type CSIVolume struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec CSIVolumeSpec `json:"spec"`
+	Spec   CSIVolumeSpec   `json:"spec"`
+	Status CSIVolumeStatus `json: "status"`
 }
 
 // CSIVolumeSpec is the spec for a CStorVolume resource
@@ -113,6 +114,20 @@ type ISCSIInfo struct {
 	// iSCSI Volume. (default: 0)
 	Lun string `json:"lun"`
 }
+
+// CSIVolumeStatus status represents the current mount status of the volume
+type CSIVolumeStatus string
+
+// CSIVolumeStatusMounting indicated that a mount operation has been triggered
+// on the volume and is under progress
+const (
+	CSIVolumeStatusUninitialized      CSIVolumeStatus = ""
+	CSIVolumeStatusMountUnderProgress CSIVolumeStatus = "MountUnderProgress"
+	CSIVolumeStatusMounted            CSIVolumeStatus = "Mounted"
+	CSIVolumeStatusUnMounted          CSIVolumeStatus = "UnMounted"
+	CSIVolumeStatusRaw                CSIVolumeStatus = "Raw"
+	CSIVolumeStatusMountFailed        CSIVolumeStatus = "MountFailed"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resource:path=csivolumes

--- a/pkg/apis/openebs.io/core/v1alpha1/csivolume.go
+++ b/pkg/apis/openebs.io/core/v1alpha1/csivolume.go
@@ -121,12 +121,27 @@ type CSIVolumeStatus string
 // CSIVolumeStatusMounting indicated that a mount operation has been triggered
 // on the volume and is under progress
 const (
-	CSIVolumeStatusUninitialized      CSIVolumeStatus = ""
+	// CSIVolumeStatusUninitialized indicates that no operation has been
+	// performed on the volume yet on this node
+	CSIVolumeStatusUninitialized CSIVolumeStatus = ""
+	// CSIVolumeStatusMountUnderProgress indicates that the volume is busy and
+	// unavailable for use by other goroutines, an iSCSI login followed by mount
+	// is under progress on this volume
 	CSIVolumeStatusMountUnderProgress CSIVolumeStatus = "MountUnderProgress"
-	CSIVolumeStatusMounted            CSIVolumeStatus = "Mounted"
-	CSIVolumeStatusUnMounted          CSIVolumeStatus = "UnMounted"
-	CSIVolumeStatusRaw                CSIVolumeStatus = "Raw"
-	CSIVolumeStatusMountFailed        CSIVolumeStatus = "MountFailed"
+	// CSIVolumeStatusMounteid indicated that the volume has been successfulled
+	// mounted on the node
+	CSIVolumeStatusMounted CSIVolumeStatus = "Mounted"
+	// CSIVolumeStatusUnMounted indicated that the volume has been successfuly
+	// unmounted and logged out of the node
+	CSIVolumeStatusUnMounted CSIVolumeStatus = "UnMounted"
+	// CSIVolumeStatusRaw indicates that the volume is being used in raw format
+	// by the application, therefore CSI has only performed iSCSI login
+	// operation on this volume and avoided filesystem creation and mount.
+	CSIVolumeStatusRaw CSIVolumeStatus = "Raw"
+	// CSIVolumeStatusMountFailed indicates that login and mount process from
+	// the volume has bben started but failed kubernetes needs to retry sending
+	// nodepublish
+	CSIVolumeStatusMountFailed CSIVolumeStatus = "MountFailed"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/generated/clientset/core/internalclientset/typed/core/v1alpha1/csivolume.go
+++ b/pkg/generated/clientset/core/internalclientset/typed/core/v1alpha1/csivolume.go
@@ -39,6 +39,7 @@ type CSIVolumesGetter interface {
 type CSIVolumeInterface interface {
 	Create(*v1alpha1.CSIVolume) (*v1alpha1.CSIVolume, error)
 	Update(*v1alpha1.CSIVolume) (*v1alpha1.CSIVolume, error)
+	UpdateStatus(*v1alpha1.CSIVolume) (*v1alpha1.CSIVolume, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.CSIVolume, error)
@@ -126,6 +127,22 @@ func (c *cSIVolumes) Update(cSIVolume *v1alpha1.CSIVolume) (result *v1alpha1.CSI
 		Namespace(c.ns).
 		Resource("csivolumes").
 		Name(cSIVolume.Name).
+		Body(cSIVolume).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+
+func (c *cSIVolumes) UpdateStatus(cSIVolume *v1alpha1.CSIVolume) (result *v1alpha1.CSIVolume, err error) {
+	result = &v1alpha1.CSIVolume{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("csivolumes").
+		Name(cSIVolume.Name).
+		SubResource("status").
 		Body(cSIVolume).
 		Do().
 		Into(result)

--- a/pkg/generated/clientset/core/internalclientset/typed/core/v1alpha1/fake/fake_csivolume.go
+++ b/pkg/generated/clientset/core/internalclientset/typed/core/v1alpha1/fake/fake_csivolume.go
@@ -100,6 +100,18 @@ func (c *FakeCSIVolumes) Update(cSIVolume *v1alpha1.CSIVolume) (result *v1alpha1
 	return obj.(*v1alpha1.CSIVolume), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeCSIVolumes) UpdateStatus(cSIVolume *v1alpha1.CSIVolume) (*v1alpha1.CSIVolume, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(csivolumesResource, "status", c.ns, cSIVolume), &v1alpha1.CSIVolume{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.CSIVolume), err
+}
+
 // Delete takes name of the cSIVolume and deletes it. Returns an error if one occurs.
 func (c *FakeCSIVolumes) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.

--- a/pkg/service/v1alpha1/node.go
+++ b/pkg/service/v1alpha1/node.go
@@ -119,8 +119,11 @@ verifyPublish:
 		// The volume appears to be present in the inmomory list of volumes
 		// which implies that either the mount operation is complete
 		// or under progress.
-		// Lets verify if the mount is already completed
 		if info.Spec.Volume.MountPath != mountPath {
+			// The volume appears to be mounted on a different path, which
+			// implies it is being used by some other pod on the same node.
+			// Let's wait fo the volume to be unmounted from the other path and
+			// then retry checking
 			utils.VolumesListLock.Unlock()
 			if !reVerified {
 				time.Sleep(
@@ -134,6 +137,7 @@ verifyPublish:
 					codes.Internal,
 					"Volume Mounted by a different pod on same node",
 				)
+			// Lets verify if the mount is already completed
 		} else if info.Spec.Volume.DevicePath != "" {
 			// Once the devicePath is set implies the volume mount has been
 			// completed, a success response can be sent back

--- a/pkg/service/v1alpha1/node.go
+++ b/pkg/service/v1alpha1/node.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -44,28 +45,11 @@ func NewNode(d *CSIDriver) csi.NodeServer {
 	}
 }
 
-// NodePublishVolume publishes (mounts) the volume
-// at the corresponding node at a given path
-//
-// This implements csi.NodeServer
-func (ns *node) NodePublishVolume(
-	ctx context.Context,
+func prepareVolSpecAndWaitForVolumeReady(
 	req *csi.NodePublishVolumeRequest,
-) (*csi.NodePublishVolumeResponse, error) {
-
-	var (
-		err        error
-		reVerified bool
-		devicePath string
-	)
-
-	if err = ns.validateNodePublishReq(req); err != nil {
-		return nil, err
-	}
-
-	mountPath := req.GetTargetPath()
+	nodeID string,
+) (*apis.CSIVolume, error) {
 	volumeID := req.GetVolumeId()
-
 	vol, err := csivol.NewBuilder().
 		WithName(req.GetVolumeId()).
 		WithVolName(req.GetVolumeId()).
@@ -74,31 +58,28 @@ func (ns *node) NodePublishVolume(
 		WithMountOptions(req.GetVolumeCapability().GetMount().GetMountFlags()).
 		WithReadOnly(req.GetReadonly()).Build()
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, err
 	}
 
-	if err = utils.PatchCVCNodeID(volumeID, ns.driver.config.NodeID); err != nil {
-		return nil,
-			status.Error(codes.Internal, err.Error())
+	if err = utils.PatchCVCNodeID(volumeID, nodeID); err != nil {
+		return nil, err
 	}
 
 	if isCVCBound, err := utils.IsCVCBound(volumeID); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	} else if !isCVCBound {
 		time.Sleep(10 * time.Second)
-		return nil, status.Error(codes.Internal, "Waiting for CVC to be bound")
+		return nil, fmt.Errorf("Waiting for CVC to be bound")
 	}
 
 	if err = utils.FetchAndUpdateISCSIDetails(volumeID, vol); err != nil {
-		return nil,
-			status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	//Check if volume is ready to serve IOs,
 	//info is fetched from the cstorvolume CR
 	if err := utils.WaitForVolumeToBeReady(volumeID); err != nil {
-		return nil,
-			status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	// A temporary TCP connection is made to the volume to check if its
@@ -109,10 +90,66 @@ func (ns *node) NodePublishVolume(
 		return nil,
 			status.Error(codes.Internal, err.Error())
 	}
+	return vol, nil
+}
 
-	// TODO put this tag in a function and defer to unlock in this function
-verifyPublish:
+func cleanup(vol *apis.CSIVolume, nodeID string) error {
 	utils.VolumesListLock.Lock()
+	vol.Status = apis.CSIVolumeStatusMountFailed
+	if err := utils.DeleteOldCSIVolumeCR(
+		vol, nodeID,
+	); err != nil {
+		utils.VolumesListLock.Unlock()
+		return err
+	}
+	delete(utils.Volumes, vol.Spec.Volume.Name)
+	utils.VolumesListLock.Unlock()
+	return nil
+}
+
+func updateCSIVolume(
+	vol *apis.CSIVolume,
+	volStatus apis.CSIVolumeStatus,
+	mountPath, devicePath string,
+) error {
+	// Setting the devicePath in the volume spec is an indication that the mount
+	// operation for the volume has been completed for the first time. This
+	// helps in 2 ways:
+	// 1) Duplicate nodePublish requests from kubernetes are responded with
+	//    success response if this path is set
+	// 2) The volumeMonitoring thread doesn't attemp remount unless this path is
+	//    set
+	utils.VolumesListLock.Lock()
+	vol.Status = volStatus
+	vol.Spec.Volume.DevicePath = devicePath
+	err := utils.UpdateCSIVolumeCR(vol)
+	if err != nil {
+		utils.VolumesListLock.Unlock()
+		return err
+	}
+	utils.VolumesListLock.Unlock()
+	return nil
+}
+
+func wait() {
+	utils.VolumesListLock.Unlock()
+	time.Sleep(
+		utils.VolumeWaitRetryCount * utils.VolumeWaitTimeout * time.Second,
+	)
+	utils.VolumesListLock.Lock()
+}
+
+func verifyInprogressAndRecreateCSIVolumeCR(vol *apis.CSIVolume) (bool, error) {
+	var (
+		reVerified bool
+		err        error
+	)
+	mountPath := vol.Spec.Volume.MountPath
+	volumeID := vol.Spec.Volume.Name
+	nodeID := vol.Labels["nodeID"]
+	utils.VolumesListLock.Lock()
+	defer utils.VolumesListLock.Unlock()
+verifyPublish:
 	// Check if the volume has already been published(mounted) or if the mount
 	// is in progress
 	if info, ok := utils.Volumes[volumeID]; ok {
@@ -124,68 +161,86 @@ verifyPublish:
 			// implies it is being used by some other pod on the same node.
 			// Let's wait fo the volume to be unmounted from the other path and
 			// then retry checking
-			utils.VolumesListLock.Unlock()
 			if !reVerified {
-				time.Sleep(
-					utils.VolumeWaitRetryCount * utils.VolumeWaitTimeout * time.Second,
-				)
 				reVerified = true
+				wait()
 				goto verifyPublish
 			}
-			return nil,
-				status.Error(
-					codes.Internal,
-					"Volume Mounted by a different pod on same node",
-				)
+			return false, fmt.Errorf(
+				"Volume Mounted by a different pod on same node")
 			// Lets verify if the mount is already completed
 		} else if info.Spec.Volume.DevicePath != "" {
 			// Once the devicePath is set implies the volume mount has been
 			// completed, a success response can be sent back
-			utils.VolumesListLock.Unlock()
-			return &csi.NodePublishVolumeResponse{}, nil
+			return true, nil
 		} else if info.Status == apis.CSIVolumeStatusMountUnderProgress {
-			// The mount appears to be under progress lets wait for 13 seconds and
-			// reverify. 13s was decided based on the kubernetes timeout values
-			// which is 15s. Lets reply to kubernetes before it reattempts a
-			// duplicate request
-			utils.VolumesListLock.Unlock()
+			// The mount appears to be under progress lets wait for 13 seconds
+			// and reverify. 13s was decided based on the kubernetes timeout
+			// values which is 15s. Lets reply to kubernetes before it reattempts
+			// a duplicate request
 			if !reVerified {
-				time.Sleep(
-					utils.VolumeWaitRetryCount * utils.VolumeWaitTimeout * time.Second,
-				)
+				wait()
 				reVerified = true
 				goto verifyPublish
 			}
 			// It appears that the mount will still take some more time,
 			// lets convey the same to kubernetes. The message responded will be
 			// added to the app description which has requested this volume
-			return nil, status.Error(codes.Internal, "Mount under progress")
+			return false, fmt.Errorf("Mount under progress")
 		}
 	}
-
 	// This helps in cases when the node on which the volume was originally
 	// mounted is down. When that node is down, kubelet would not have been able
 	// to trigger an unpublish event on that node due to which when it comes up
 	// it starts remounting that volume. If the node's CSIVolume CR is marked
 	// for deletion that node will not reattempt to mount this volume again.
 	if err = utils.DeleteOldCSIVolumeCR(
-		vol, ns.driver.config.NodeID,
+		vol, nodeID,
 	); err != nil {
-		utils.VolumesListLock.Unlock()
-		return nil, status.Error(codes.Internal, err.Error())
+		return false, err
 	}
 	// This CR creation will help iSCSI target(istgt) identify
 	// the current owner node of the volume and accordingly the target will
 	// allow only that node to login to the volume
 	vol.Status = apis.CSIVolumeStatusMountUnderProgress
-	err = utils.CreateCSIVolumeCR(vol, ns.driver.config.NodeID, mountPath)
+	err = utils.CreateCSIVolumeCR(vol, nodeID, mountPath)
 	if err != nil {
-		utils.VolumesListLock.Unlock()
-		return nil, status.Error(codes.Internal, err.Error())
+		return false, err
 	}
 	utils.Volumes[volumeID] = vol
-	utils.VolumesListLock.Unlock()
+	return false, nil
+}
 
+// NodePublishVolume publishes (mounts) the volume
+// at the corresponding node at a given path
+//
+// This implements csi.NodeServer
+func (ns *node) NodePublishVolume(
+	ctx context.Context,
+	req *csi.NodePublishVolumeRequest,
+) (*csi.NodePublishVolumeResponse, error) {
+
+	var (
+		err        error
+		devicePath string
+	)
+
+	if err = ns.validateNodePublishReq(req); err != nil {
+		return nil, err
+	}
+
+	mountPath := req.GetTargetPath()
+	nodeID := ns.driver.config.NodeID
+
+	vol, err := prepareVolSpecAndWaitForVolumeReady(req, nodeID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if isMounted, err := verifyInprogressAndRecreateCSIVolumeCR(vol); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	} else if isMounted == true {
+		goto CreateVolumeResponseSuccess
+	}
 	// Permission is changed for the local directory before the volume is
 	// mounted on the node. This helps to resolve cases when the CSI driver
 	// Unmounts the volume to remount again in required mount mode(ro/rw),
@@ -195,50 +250,27 @@ verifyPublish:
 	// And as soon as it is unmounted permissions change
 	// back to what we are setting over here.
 	if err = utils.ChmodMountPath(vol.Spec.Volume.MountPath); err != nil {
-		utils.VolumesListLock.Lock()
-		vol.Status = apis.CSIVolumeStatusMountFailed
-		if err = utils.DeleteOldCSIVolumeCR(
-			vol, ns.driver.config.NodeID,
-		); err != nil {
-			utils.VolumesListLock.Unlock()
+		if err := cleanup(vol, nodeID); err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		delete(utils.Volumes, volumeID)
-		utils.VolumesListLock.Unlock()
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	// Login to the volume and attempt mount operation on the requested path
 	if devicePath, err = iscsi.AttachAndMountDisk(vol); err != nil {
-		utils.VolumesListLock.Lock()
-		vol.Status = apis.CSIVolumeStatusMountFailed
-		if err = utils.DeleteOldCSIVolumeCR(
-			vol, ns.driver.config.NodeID,
-		); err != nil {
-			utils.VolumesListLock.Unlock()
+		if err := cleanup(vol, nodeID); err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		delete(utils.Volumes, volumeID)
-		utils.VolumesListLock.Unlock()
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	// Setting the devicePath in the volume spec is an indication that the mount
-	// operation for the volume has been completed for the first time. This
-	// helps in 2 ways:
-	// 1) Duplicate nodePublish requests from kubernetes are responded with
-	//    success response if this path is set
-	// 2) The volumeMonitoring thread doesn't attemp remount unless this path is
-	//    set
-	utils.VolumesListLock.Lock()
-	vol.Status = apis.CSIVolumeStatusMounted
-	vol.Spec.Volume.DevicePath = devicePath
-	err = utils.UpdateCSIVolumeCR(vol)
-	if err != nil {
-		utils.VolumesListLock.Unlock()
+	if err := updateCSIVolume(
+		vol, apis.CSIVolumeStatusMounted,
+		mountPath, devicePath,
+	); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	utils.VolumesListLock.Unlock()
 
+CreateVolumeResponseSuccess:
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
@@ -398,7 +430,9 @@ func (ns *node) NodeGetVolumeStats(
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-func (ns *node) validateNodePublishReq(req *csi.NodePublishVolumeRequest) error {
+func (ns *node) validateNodePublishReq(
+	req *csi.NodePublishVolumeRequest,
+) error {
 	if req.GetVolumeCapability() == nil {
 		return status.Error(codes.InvalidArgument,
 			"Volume capability missing in request")
@@ -411,7 +445,9 @@ func (ns *node) validateNodePublishReq(req *csi.NodePublishVolumeRequest) error 
 	return nil
 }
 
-func (ns *node) validateNodeUnpublishReq(req *csi.NodeUnpublishVolumeRequest) error {
+func (ns *node) validateNodeUnpublishReq(
+	req *csi.NodeUnpublishVolumeRequest,
+) error {
 	if req.GetVolumeId() == "" {
 		return status.Error(codes.InvalidArgument,
 			"Volume ID missing in request")

--- a/pkg/service/v1alpha1/node.go
+++ b/pkg/service/v1alpha1/node.go
@@ -50,8 +50,13 @@ func prepareVolSpecAndWaitForVolumeReady(
 	nodeID string,
 ) (*apis.CSIVolume, error) {
 	volumeID := req.GetVolumeId()
+	labels := map[string]string{
+		"nodeID": nodeID,
+	}
+
 	vol, err := csivol.NewBuilder().
 		WithName(req.GetVolumeId()).
+		WithLabels(labels).
 		WithVolName(req.GetVolumeId()).
 		WithMountPath(req.GetTargetPath()).
 		WithFSType(req.GetVolumeCapability().GetMount().GetFsType()).

--- a/pkg/service/v1alpha1/service.go
+++ b/pkg/service/v1alpha1/service.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"log"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	config "github.com/openebs/csi/pkg/config/v1alpha1"
@@ -85,7 +87,9 @@ func New(config *config.Config) *CSIDriver {
 		driver.cs = NewController(driver)
 
 	case "node":
-		utils.FetchAndUpdateVolInfos(config.NodeID)
+		if err := utils.FetchAndUpdateVolInfos(config.NodeID); err != nil {
+			log.Fatalln(err)
+		}
 
 		// Start monitor goroutine to monitor the
 		// mounted paths. If a path goes down or

--- a/pkg/service/v1alpha1/service.go
+++ b/pkg/service/v1alpha1/service.go
@@ -85,7 +85,7 @@ func New(config *config.Config) *CSIDriver {
 		driver.cs = NewController(driver)
 
 	case "node":
-		// utils.FetchAndUpdateVolInfos(config.NodeID)
+		utils.FetchAndUpdateVolInfos(config.NodeID)
 
 		// Start monitor goroutine to monitor the
 		// mounted paths. If a path goes down or

--- a/pkg/utils/v1alpha1/kubernetes.go
+++ b/pkg/utils/v1alpha1/kubernetes.go
@@ -86,6 +86,20 @@ func CreateCSIVolumeCR(csivol *apis.CSIVolume, nodeID, mountPath string) (err er
 	return
 }
 
+// UpdateCSIVolumeCR updates CSIVolume CR related to current nodeID
+func UpdateCSIVolumeCR(csivol *apis.CSIVolume) error {
+
+	oldcsivol, err := csivolume.NewKubeclient().WithNamespace(OpenEBSNamespace).Get(csivol.Name, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	oldcsivol.Spec.Volume.DevicePath = csivol.Spec.Volume.DevicePath
+	oldcsivol.Status = csivol.Status
+
+	_, err = csivolume.NewKubeclient().WithNamespace(OpenEBSNamespace).Update(oldcsivol)
+	return err
+}
+
 // DeleteOldCSIVolumeCR deletes all CSIVolumes
 // related to this volume so that a new one
 // can be created with node as current nodeID
@@ -100,7 +114,10 @@ func DeleteOldCSIVolumeCR(vol *apis.CSIVolume, nodeID string) (err error) {
 		return
 	}
 
-	// TODO Add description why multiple CRs can be there for one volume
+	// If a node goes down and kubernetes is unable to send an Unpublish request
+	// to this node, the CR is marked for deletion but finalizer is not removed
+	// and a new CR is created for current node. When the degraded node comes up
+	// it removes the finalizer and the CR is deleted.
 	for _, csivol := range csivols.Items {
 		if csivol.Labels["nodeID"] == nodeID {
 			csivol.Finalizers = nil
@@ -173,7 +190,13 @@ func FetchAndUpdateVolInfos(nodeID string) (err error) {
 	}
 
 	for _, csivol := range csivols.Items {
+		if csivol.DeletionTimestamp != nil {
+			continue
+		}
 		vol := csivol
+		if vol.Status == apis.CSIVolumeStatusMountUnderProgress {
+			vol.Status = apis.CSIVolumeStatusUninitialized
+		}
 		Volumes[csivol.Spec.Volume.Name] = &vol
 	}
 

--- a/pkg/utils/v1alpha1/kubernetes.go
+++ b/pkg/utils/v1alpha1/kubernetes.go
@@ -190,7 +190,7 @@ func FetchAndUpdateVolInfos(nodeID string) (err error) {
 	}
 
 	for _, csivol := range csivols.Items {
-		if csivol.DeletionTimestamp != nil {
+		if !csivol.DeletionTimestamp.IsZero() {
 			continue
 		}
 		vol := csivol

--- a/pkg/volume/v1alpha1/build.go
+++ b/pkg/volume/v1alpha1/build.go
@@ -282,6 +282,53 @@ func (b *Builder) WithReadOnly(readOnly bool) *Builder {
 	return b
 }
 
+// WithLabels merges existing labels of csi volume if any
+// with the ones that are provided here
+func (b *Builder) WithLabels(labels map[string]string) *Builder {
+	if len(labels) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build csi volume object: missing labels",
+			),
+		)
+		return b
+	}
+
+	if b.volume.Object.Labels == nil {
+		return b.WithLabelsNew(labels)
+	}
+
+	for key, value := range labels {
+		b.volume.Object.Labels[key] = value
+	}
+	return b
+}
+
+// WithLabelsNew resets existing labels of csi volume if any with
+// ones that are provided here
+func (b *Builder) WithLabelsNew(labels map[string]string) *Builder {
+	if len(labels) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build csi volume object: no new labels",
+			),
+		)
+		return b
+	}
+
+	// copy of original map
+	newlbls := map[string]string{}
+	for key, value := range labels {
+		newlbls[key] = value
+	}
+
+	// override
+	b.volume.Object.Labels = newlbls
+	return b
+}
+
 // Build returns csi volume API object
 func (b *Builder) Build() (*apis.CSIVolume, error) {
 	if len(b.errs) > 0 {


### PR DESCRIPTION
This PR fixes the issue when Kubernetes sends a Publish Volume request on a node for a new pod with same VolumeID before unpublishing the old one.
Following changes have been implemented:
1) Status field has been added to CSI Volume CR.
2) Mountpath is also being compared
3) CSI Volume CRs are being read while coming up