### PR TITLE
refact(cvc): use cstorPoolCluster name instead of storagePoolClaim

### DIFF
--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -15,6 +15,7 @@
 #!/usr/bin/env bash
 
 OPENEBS_OPERATOR=https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
+CSPC_OPERATOR=https://raw.githubusercontent.com/openebs/openebs/master/k8s/cspc-operator.yaml
 CSI_OPERATOR="$GOPATH/src/github.com/openebs/csi/deploy/csi-operator.yaml"
 
 SRC_REPO="https://github.com/openebs/maya.git"
@@ -23,6 +24,7 @@ DST_PATH="$GOPATH/src/github.com/openebs"
 # Prepare env for runnging BDD tests
 # Minikube is already running
 kubectl apply -f $OPENEBS_OPERATOR
+kubectl apply -f $CSPC_OPERATOR
 kubectl apply -f $CSI_OPERATOR
 
 # Start running BDD tests in maya for CSI

--- a/pkg/utils/v1alpha1/maya.go
+++ b/pkg/utils/v1alpha1/maya.go
@@ -23,8 +23,8 @@ const (
 	OpenebsConfigClass = "openebs.io/config-class"
 	// OpenebsVolumeID is the PV name passed to CSI
 	OpenebsVolumeID = "openebs.io/volumeID"
-	// OpenebsSPCName is the name of cstor storagepool cluster
-	OpenebsSPCName = "openebs.io/storage-pool-claim"
+	// OpenebsCSPCName is the name of cstor storagepool cluster
+	OpenebsCSPCName = "openebs.io/cstor-pool-cluster"
 	// CVCFinalizer is used for CVC protection so that cvc is not deleted until
 	// the underlying cv is deleted
 	CVCFinalizer = "cvc.openebs.io/finalizer"
@@ -41,7 +41,7 @@ func ProvisionVolume(
 	size int64,
 	volName,
 	replicaCount,
-	spcName string,
+	cspcName string,
 ) error {
 
 	annotations := map[string]string{
@@ -49,7 +49,7 @@ func ProvisionVolume(
 	}
 
 	labels := map[string]string{
-		OpenebsSPCName: spcName,
+		OpenebsCSPCName: cspcName,
 	}
 
 	finalizers := []string{


### PR DESCRIPTION
1. This commit gets `CStorPoolCluster` name from storageclass parameters
and set as label in `cstorvolumeclaim` resource which will be used to
distribute the replica in cstorpool instances.

2. Get the `cas-type` from storageclass and populate as VolumeContext info.
 this parameter is needed to differentiate b/w different openebs volume types i.e. `cstor` and `jiva` etc.

**StorageClass example**:

```yaml
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: cstor-sparse-auto
provisioner: openebs-csi.openebs.io
allowVolumeExpansion: true
parameters:
  replicaCount: "1"
  cstorPoolCluster: "cspc-sparse-pool"
  cas-type: "cstor"

```

**CStorVolumeClaim example**:

```yaml
apiVersion: openebs.io/v1alpha1
kind: CStorVolumeClaim
metadata:
  annotations:
    openebs.io/volumeID: pvc-8090ff6d-fb47-4464-b564-d2803dbc8cdc
  creationTimestamp: "2019-07-29T12:08:01Z"
  finalizers:
  - cvc.openebs.io/finalizer
  generation: 147
  labels:
    openebs.io/cstor-pool-cluster: cspc-sparse-pool
  name: pvc-8090ff6d-fb47-4464-b564-d2803dbc8cdc
  namespace: openebs
  resourceVersion: "4989"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/cstorvolumeclaims/pvc-8090ff6d-fb47-4464-b564-d2803dbc8cdc
  uid: 6216eb91-e0d5-4f2a-b7fb-3907e0d71fac
publish:
  nodeId: 127.0.0.1
spec:
  capacity:
    storage: "5368709120"
  cstorVolumeRef:
    apiVersion: openebs.io/v1alpha1
    kind: CStorVolume
    name: pvc-8090ff6d-fb47-4464-b564-d2803dbc8cdc
    namespace: openebs
    resourceVersion: "3336"
    uid: fb31906d-9d4b-468f-94b9-f76a7ab5e204
  replicaCount: 1
status:
  capacity:
    storage: "5368709120"
  phase: Bound

```
Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>