### PR TITLE
refact(travis): bump minikube version v1.4.0 to use k8s v1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ install:
 - make bootstrap
 - make format
 before_script:
-- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl
+- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl
   && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-- curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.1.0/minikube-linux-amd64
+- curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.4.0/minikube-linux-amd64
   && chmod +x minikube && sudo mv minikube /usr/local/bin/
 - mkdir -p $HOME/.kube $HOME/.minikube
 - touch $KUBECONFIG
-- sudo minikube start --vm-driver=none --kubernetes-version=v1.14.2
+- sudo minikube start --vm-driver=none --kubernetes-version=v1.16.0
 - 'sudo chown -R travis: /home/travis/.minikube/'
 - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}';
   until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do

--- a/deploy/csi-operator-ubuntu-18.04.yaml
+++ b/deploy/csi-operator-ubuntu-18.04.yaml
@@ -1,7 +1,7 @@
-# This manifest deploys the OpenEBS CSI control plane components, 
-# with associated CRs & RBAC rules. This manifest has been verified 
-# only with Ubuntu 16.04 and CentOS hosts, due to dependencies on 
-# kernel components of iSCSI protocol.  For other ubuntu flavours and 
+# This manifest deploys the OpenEBS CSI control plane components,
+# with associated CRs & RBAC rules. This manifest has been verified
+# only with Ubuntu 16.04 and CentOS hosts, due to dependencies on
+# kernel components of iSCSI protocol.  For other ubuntu flavours and
 # linux distros, this needs to be modified.
 #
 # Instructions to modify:
@@ -140,7 +140,7 @@ roleRef:
 
 ---
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: openebs-csi-controller
   namespace: kube-system
@@ -400,7 +400,7 @@ roleRef:
 ---
 
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: openebs-csi-node
   namespace: kube-system

--- a/deploy/csi-operator.yaml
+++ b/deploy/csi-operator.yaml
@@ -1,7 +1,7 @@
-# This manifest deploys the OpenEBS CSI control plane components, 
-# with associated CRs & RBAC rules. This manifest has been verified 
-# only with Ubuntu 16.04 and CentOS hosts, due to dependencies on 
-# kernel components of iSCSI protocol.  For other ubuntu flavours and 
+# This manifest deploys the OpenEBS CSI control plane components,
+# with associated CRs & RBAC rules. This manifest has been verified
+# only with Ubuntu 16.04 and CentOS hosts, due to dependencies on
+# kernel components of iSCSI protocol.  For other ubuntu flavours and
 # linux distros, this needs to be modified.
 #
 # Instructions to modify:
@@ -140,7 +140,7 @@ roleRef:
 
 ---
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: openebs-csi-controller
   namespace: kube-system
@@ -400,7 +400,7 @@ roleRef:
 ---
 
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: openebs-csi-node
   namespace: kube-system


### PR DESCRIPTION
### Why we need this change
Resize support has been added as part of `1.15`  kuberntes version as feature gate enable which required to bump the travis k8s version to `1.15+`

This change missed to as part of resize BDD changes.

- update k8s version 1.16.0
- update k8s API's kind for statefulset and daemontset to use `apps/v1`

Cherry-pick #39 

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>